### PR TITLE
Fix TF searchsorted vectorized map support

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2175,9 +2175,14 @@ def searchsorted(sorted_sequence, values, side="left"):
             "to extend it to N-D sequences. Received: "
             f"sorted_sequence.shape={sorted_sequence.shape}"
         )
-    out_type = (
-        "int32" if len(sorted_sequence) <= np.iinfo(np.int32).max else "int64"
-    )
+    out_type = "int32"
+
+    static_length = sorted_sequence.shape[0]
+    if static_length is None:
+        static_length = tf.get_static_value(tf.shape(sorted_sequence)[0])
+    if static_length is not None:
+        if int(static_length) > np.iinfo(np.int32).max:
+            out_type = "int64"
     return tf.searchsorted(
         sorted_sequence, values, side=side, out_type=out_type
     )

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -4545,6 +4545,26 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllEqual(knp.searchsorted(a, v), expected)
         self.assertAllEqual(knp.SearchSorted()(a, v), expected)
 
+    def test_searchsorted_vectorized_map_tensorflow(self):
+        if backend.backend() != "tensorflow":
+            self.skipTest("Only relevant for the TensorFlow backend.")
+
+        xs = keras.ops.stack(
+            [keras.ops.linspace(0.0, 1.0, 5) for _ in range(3)], axis=-1
+        )
+        inputs = keras.random.uniform((10, 3), seed=123)
+
+        result = keras.ops.vectorized_map(
+            lambda i: keras.ops.searchsorted(xs[:, i], inputs[:, i]),
+            keras.ops.arange(3),
+        )
+        expected = keras.ops.stack(
+            [keras.ops.searchsorted(xs[:, i], inputs[:, i]) for i in range(3)],
+            axis=0,
+        )
+
+        self.assertAllClose(result, expected)
+
     def test_sign(self):
         x = np.array([[1, -2, 3], [-3, 2, -1]])
         self.assertAllClose(knp.sign(x), np.sign(x))


### PR DESCRIPTION
## Summary
- avoid calling `len()` on symbolic tensors in the TensorFlow backend searchsorted implementation
- add a regression test ensuring searchsorted works inside keras.ops.vectorized_map on TensorFlow

## Testing
- KERAS_BACKEND=tensorflow pytest keras/src/ops/numpy_test.py -k searchsorted_vectorized_map_tensorflow -q

------
https://chatgpt.com/codex/tasks/task_e_68cdd6b76ee48326813a9982ebf339e4